### PR TITLE
Add KDE to Communities

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
    - [Open Source Initiative](https://opensource.org)
    - [The Linux Foundation](https://www.linuxfoundation.org)
    - [GNOME Community](https://wiki.gnome.org/Community)
+   - [KDE Community](https://community.kde.org/)
    - [EddieHub](https://github.com/EddieHubCommunity)
    - [OSS Cameroon](https://github.com/osscameroon)
    - [DVS Tech Community](https://github.com/dvstechlabs)

--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@
    - [Open Source Initiative](https://opensource.org)
    - [The Linux Foundation](https://www.linuxfoundation.org)
    - [GNOME Community](https://wiki.gnome.org/Community)
-   - [KDE Community](https://community.kde.org/)
    - [EddieHub](https://github.com/EddieHubCommunity)
    - [OSS Cameroon](https://github.com/osscameroon)
    - [DVS Tech Community](https://github.com/dvstechlabs)
+   - [KDE Community](https://community.kde.org)
     
 </details>
 


### PR DESCRIPTION
Super small change that adds KDE to communities with a link to the wiki where you can get started both as a user or a contributor.